### PR TITLE
Add UniversalPackage support

### DIFF
--- a/examples/universal_package/build.sh
+++ b/examples/universal_package/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+set -e
+echo BUILDDIR=$BUILDDIR
+cp src/main.py $BUILDDIR

--- a/examples/universal_package/launch.py
+++ b/examples/universal_package/launch.py
@@ -1,0 +1,25 @@
+# type: ignore
+
+from absl import app
+
+from lxm3 import xm
+from lxm3 import xm_cluster
+
+
+def main(_):
+    with xm_cluster.create_experiment(experiment_title="universal") as experiment:
+        executor = xm_cluster.Local()
+        executable = xm.Packageable(
+            xm_cluster.UniversalPackage(
+                path=".",
+                entrypoint=["python3", "main.py"],
+                build_script="build.sh",
+            ),
+            xm_cluster.Local.Spec(),  # type: ignore
+        )
+        [executable] = experiment.package([executable])
+        experiment.add(xm.Job(executable=executable, executor=executor))
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/examples/universal_package/src/main.py
+++ b/examples/universal_package/src/main.py
@@ -1,0 +1,6 @@
+def main():
+    print("Hello world")
+
+
+if __name__ == "__main__":
+    main()

--- a/lxm3/xm_cluster/__init__.py
+++ b/lxm3/xm_cluster/__init__.py
@@ -4,6 +4,7 @@ from lxm3.xm_cluster.executable_specs import Fileset
 from lxm3.xm_cluster.executable_specs import ModuleName
 from lxm3.xm_cluster.executable_specs import PythonPackage
 from lxm3.xm_cluster.executable_specs import SingularityContainer
+from lxm3.xm_cluster.executable_specs import UniversalPackage
 from lxm3.xm_cluster.executables import Command
 from lxm3.xm_cluster.executors import GridEngine
 from lxm3.xm_cluster.executors import Local

--- a/tests/packaging_test.py
+++ b/tests/packaging_test.py
@@ -1,5 +1,6 @@
 import os
 import unittest.mock
+import zipfile
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -8,13 +9,15 @@ from lxm3 import xm
 from lxm3 import xm_cluster
 from lxm3.xm_cluster import packaging
 
+_HERE = os.path.abspath(os.path.dirname(__file__))
+
 
 class PackagingTest(parameterized.TestCase):
     @unittest.mock.patch("subprocess.run")
     def test_package_python(self, mock_run):
         spec = xm_cluster.PythonPackage(
             entrypoint=xm_cluster.ModuleName("py_package.main"),
-            path=os.path.join(os.path.dirname(__file__), "testdata/test_pkg"),
+            path=os.path.join(_HERE, "testdata/test_pkg"),
         )
         executable = packaging._package_python_package(
             spec,
@@ -24,6 +27,33 @@ class PackagingTest(parameterized.TestCase):
             ),
         )
         self.assertIsInstance(executable, xm_cluster.Command)
+
+    def test_package_universal(self):
+        spec = xm_cluster.UniversalPackage(
+            entrypoint=["python3", "main.py"],
+            path=os.path.join(_HERE, "testdata/test_universal"),
+            build_script="build.sh",
+        )
+        executable = packaging._package_universal_package(
+            spec,
+            xm.Packageable(
+                spec,
+                xm_cluster.Local().Spec(),
+            ),
+        )
+        self.assertIsInstance(executable, xm_cluster.Command)
+        # Check that archive exists
+        self.assertTrue(os.path.exists(executable.resource_uri))
+        archive = zipfile.ZipFile(executable.resource_uri)
+        self.assertEqual(set(archive.namelist()), set(["main.py"]))
+
+    def test_package_universal_not_executable(self):
+        with self.assertRaises(ValueError):
+            xm_cluster.UniversalPackage(
+                entrypoint=["python3", "main.py"],
+                path=os.path.join(_HERE, "testdata/test_universal"),
+                build_script="build_not_executable.sh",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/testdata/test_universal/build.sh
+++ b/tests/testdata/test_universal/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+set -e
+echo BUILDDIR=$BUILDDIR
+cp main.py $BUILDDIR

--- a/tests/testdata/test_universal/build_not_executable.sh
+++ b/tests/testdata/test_universal/build_not_executable.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+set -e
+echo BUILDDIR=$BUILDDIR
+cp main.py $BUILDDIR


### PR DESCRIPTION
Add an ExecutableSpec called UniversalPackage.
This can be used for packaging apps that does not use standard python packaging tools.