### PR TITLE
Add pip as a dependency

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:7de721c1127817e491bc8f47043f2e44d65e7b857c25814a0a75c2a6f9d43bd6"
+content_hash = "sha256:701b17cdf3b97dd0e3958cacf760b6621580534b8d7122ed7d32ecc712d08e73"
 
 [[package]]
 name = "absl-py"
@@ -836,6 +836,16 @@ summary = "Utility library for gitignore style pattern matching of file paths."
 files = [
     {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
     {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
+]
+
+[[package]]
+name = "pip"
+version = "23.3.1"
+requires_python = ">=3.7"
+summary = "The PyPA recommended tool for installing Python packages."
+files = [
+    {file = "pip-23.3.1-py3-none-any.whl", hash = "sha256:55eb67bb6171d37447e82213be585b75fe2b12b359e993773aca4de9247a052b"},
+    {file = "pip-23.3.1.tar.gz", hash = "sha256:1fcaa041308d01f14575f6d0d2ea4b75a3e2871fe4f9c694976f908768e14174"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
   "immutabledict",
   "rich",
   "vcsinfo",
-  "docker"
+  "docker",
+  "pip"
 ]
 
 [project.urls]


### PR DESCRIPTION
`pip` may not be installed if the user uses lxm3 inside a PDM project